### PR TITLE
Add pyarrow and fastparquet to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ wandb==0.16.1
 accelerate==0.25.0
 pyarrow
 fastparquet
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ urllib3==2.1.0
 google-generativeai==0.3.1
 wandb==0.16.1
 accelerate==0.25.0
+pyarrow
+fastparquet
+


### PR DESCRIPTION
Needed these during 0 -> 1 setup today.

Didn't fix version, but this is what was downloaded as of 1/19/2024 ... worth fixing?
```
pyarrow==14.0.2
fastparquet==2023.10.1
```